### PR TITLE
hyper_params are shared among all callers --> Fix

### DIFF
--- a/utils/train_utils.py
+++ b/utils/train_utils.py
@@ -1,6 +1,7 @@
 import tensorflow as tf
 import math
 from utils import bbox_utils
+import copy
 
 RPN = {
     "vgg16": {
@@ -39,7 +40,7 @@ def get_hyper_params(backbone, **kwargs):
             hyper_params[key] = value
     #
     hyper_params["anchor_count"] = len(hyper_params["anchor_ratios"]) * len(hyper_params["anchor_scales"])
-    return hyper_params
+    return copy.deepcopy(hyper_params)
 
 def get_step_size(total_items, batch_size):
     """Get step size for given total item size and batch size.


### PR DESCRIPTION
At the moment the object returned by 'get_hyper_params' is shared among multiple callers. This means that if this method is called by two separate models and both model adapt their hyper_params after calling this function, one of the models might end up with the parameters from the other one.
Fix this by returning a copy instead of a reference